### PR TITLE
[update] speeling/grammar fies highlighter post

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Jeffry.in",
   "description": "Jeffry.in, Jeff Wainwright's blog",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "author": "Jeff Wainwright <yowainwright@gmail.com> (jeffry.in)",
   "bugs": {
     "url": "https://github.com/yowainwright/yowainwright.github.io/issues"

--- a/src/pages/2019-03-07-imagine-you-had-a-highlighter.md
+++ b/src/pages/2019-03-07-imagine-you-had-a-highlighter.md
@@ -11,7 +11,7 @@ categories:
 - story
 ---
 
-Listening is tough. Even when listening closely, information received by a listener is often different from what is meant to be conveyed by the speaker. Furthermore, what is perceived to be the most important information by the listener can be very different from what the speaker feels is most important. People misinterpret verbal communication all of the time! Being a part of these misunderstandings has led me to reflect ways improve this problem. I've grown fond of the idea of a highlighter pen that could highlight spoken words.
+Listening is tough. Even when listening closely, information received by a listener is often different from what is meant to be conveyed by the speaker. Furthermore, what is perceived to be the most important information by the listener can be very different from what the speaker feels is most important. People misinterpret verbal communication all of the time! Being a part of these misunderstandings has led me to reflect on ways improve this problem. I've grown fond of the idea of a highlighter pen that could highlight spoken words.
 
 <figure class='break-three-dots'>&middot; &middot; &middot;</figure>
 <figure class='highlighter-post'>
@@ -23,21 +23,21 @@ Listening is tough. Even when listening closely, information received by a liste
 
 ## Rambling on trying to convey my particular intent is a risky game I love to play, apparently
 
-For a long time I've subtly been aware that often what I'm trying to convey verbally is not what is understood by my audience. Aware of this problem, I often make it worse by attemping to convey the same point in a different way over and over. Basically, I ramble. I've experienced where people who listen to my rambling feel shut down or become hurt/pissed by one of my numerous ways of trying to convey an exact thing. This has happened at key points for me; moments where I wanted to be precise to make my listener feel understood or cared for.
+For a long time, I've subtly been aware that often what I'm trying to convey verbally is not what is understood by my audience. Aware of this problem, I usually make it worse by attempting to express the same point in a different way over and over. Basically, I ramble. I've experienced where people who listen to my rambling feel shut down or become hurt/pissed by one of my numerous ways of trying to convey an exact thing. This has happened at key points for me; moments where I wanted to be precise to make my listener feel understood or cared for.
 
 ## If I had a spoken word highlighter, I'd say it once and highlight the good s**t
 
 F\*\*king up while trying to say what I want to say has caused me to hurt relationships I care about while trying to convey how I feel about topics I care about—like my feelings. If I had a spoken word highlighter, I'd say what I felt once and highlight the good s\*\*t. I'd then ask if what I had highlighted made sense and ask how the listener interpreted what I'd said. If they did, we could move on to other important topics, like how they feel.
 
-Upon coming up with this idea, I realized I don't have a spoken word highlighter but I can ask the question or clarify what I'd like the listener to receive as highlighted.
+Upon coming up with this idea, I realized I don't have a spoken word highlighter, but I can ask the question or clarify what I'd like the listener to receive as highlighted.
 
 > "Thanks for what you've told me. If you had written down what you just said, what would you highlight with a highlighter?".
 
-With this concept speakers and listeners now take on the ability to clarify important statements.
+With this concept speakers and listeners now take on the ability to clarify essential statements.
 
 ## Other spoken word helpful concepts
 
-The concept of the highlighter is not the only grammatical tool that can be useful in verbal conversation. Suggesting that someone state a list of requests or directions with an ordered (numbered) list could help ensure that listeners understand an order. Even describing conversation change with saying "new paragraph" could clarify a change in conversation. Thinking about how we can better share communication by verbally acknowledging grammatical tools can be a useful tool for communication.
+The concept of the highlighter is not the only grammatical tool that can be useful in verbal conversation. Suggesting that someone state a list of requests or directions with an ordered (numbered) list could help ensure that listeners understand an order. Even describing conversation change by saying "new paragraph" could clarify a change in conversation. Thinking about how we can better share communication by verbally acknowledging grammatical tools can be a useful tool for communication.
 
 ## Conclusion, a potential way to heal misunderstanding
 


### PR DESCRIPTION
## Fixes

- Fixes spelling/grammar for Highlighter post
----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
