### PR TITLE
Revert "build(deps): bump gatsby-legacy-polyfills from 2.24.0 to 3.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "event-source-polyfill": "^1.0.26",
     "gatsby": "^5.0.0",
     "gatsby-codemods": "3.24.0",
-    "gatsby-legacy-polyfills": "^3.0.0",
+    "gatsby-legacy-polyfills": "^2.18.0",
     "gatsby-link": "4.24.1",
     "gatsby-plugin-google-analytics": "4.24.0",
     "gatsby-plugin-manifest": "4.24.0",


### PR DESCRIPTION
Reverts yowainwright/yowainwright.github.io#1782